### PR TITLE
Use the new official toolbx arch image and temporary workaround to fix build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
           extra-args: |
-            --target=${{ matrix.base_name }}
+            --target=${{ matrix.base_name }} --security-opt=seccomp=unconfined
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/toolbx-images/archlinux-toolbox AS arch-distrobox
+FROM quay.io/toolbx/arch-toolbox AS arch-distrobox
 
 # Pacman Initialization
 # Create build user


### PR DESCRIPTION
This PR makes two fixes that should allow the image to successfully build again.

1. The Arch toolbx image has been upstreamed from toolbx-images to be maintained by toolbx themselves, and with that comes a new image URL. This change ensures that we're consuming an up-to-date parent image, since toolbx-images is no longer building their Arch image now that it's official.

2. As of glibc 2.39, which landed in Arch recently, a few commands used during the build process (notably `pacman` and `tar`) attempt to use the new `fchmodat2` system call, which does not interact properly with the older versions of buildah/seccomp present on the actions runner. Because of this, it does not properly fall back to `fchmodat` and leads to these commands failing and/or emitting warnings related to changing permissions on files. The current workaround (until the runner updates to Ubuntu 24.04 with a more recent kernel and buildah) is to build with `seccomp=unconfined` to allow the host kernel to correctly report that the call is unsupported, causing the container to use the supported call as a fallback. While `seccomp=unconfined` is not ideal, it seems like it's the only way to make this work until the runner is updated -- a more fine-grained seccomp config to allow `fchmodat2` specifically doesn't seem to have an effect on the older version of buildah shipped in 22.04. **bazzite-arch and other downstream images will likely also need this workaround added to their actions workflows if their build process depends on fchmodat2 functioning properly.**