### PR TITLE
fix: refresh pacman-keys before downloading packages [buids should not fail anymore]

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,7 @@ FROM quay.io/toolbx/arch-toolbox AS arch-distrobox
 RUN sed -i 's/#Color/Color/g' /etc/pacman.conf && \
     printf "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" | tee -a /etc/pacman.conf && \
     sed -i 's/#MAKEFLAGS="-j2"/MAKEFLAGS="-j$(nproc)"/g' /etc/makepkg.conf && \
+    pacman-key --init && pacman-key --populate && \
     pacman -Syu --noconfirm && \
     pacman -S \
         wget \


### PR DESCRIPTION
this should fix pacman-keyring issues when the maintainer updates their signing key and the key is not yet in the preinstalled in the pacman-keyring package on the image from the registry. But still tries to download a package signed with the new key.

Builds will take a little bit longer but they should not fail anymore.

Wanted to commit these changes months ago. So the relevant build logs don't exist anymore.
Right now the builds are fine but once a maintainer updates their keys to a package that is installed in this repo it will break again.

```

File /var/cache/pacman/pkg/tldr-3.3.0-1-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] error: tldr: signature from "Brett Cornwall <brett@i--b.com>" is unknown trust error: wl-clipboard: signature from "Brett Cornwall <brett@i--b.com>" is unknown trust error: failed to commit transaction (invalid or corrupted package)

:: File /var/cache/pacman/pkg/wl-clipboard-1:2.2.1-2-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
```