### PR TITLE
chore: move adw-gtk3 from AUR to arch repos

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,7 @@ RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/dis
 
 # Install packages Distrobox adds automatically, this speeds up first launch
 RUN pacman -S \
+        adw-gtk-theme \
         bash-completion \
         bc \
         curl \
@@ -78,9 +79,9 @@ RUN git clone https://aur.archlinux.org/paru-bin.git --single-branch && \
     makepkg -si --noconfirm && \
     cd .. && \
     rm -drf paru-bin && \
-    paru -S \
-        aur/adw-gtk3 \
-        --noconfirm
+#    paru -S \
+#        aur/placeholder \
+#        --noconfirm
 USER root
 WORKDIR /
 

--- a/Containerfile
+++ b/Containerfile
@@ -78,7 +78,7 @@ RUN git clone https://aur.archlinux.org/paru-bin.git --single-branch && \
     cd paru-bin && \
     makepkg -si --noconfirm && \
     cd .. && \
-    rm -drf paru-bin && \
+    rm -drf paru-bin
 #    paru -S \
 #        aur/placeholder \
 #        --noconfirm


### PR DESCRIPTION
adw-gtk3 finally moved from AUR to offical Arch repos.

see:
https://github.com/lassekongo83/adw-gtk3/pull/265
https://archlinux.org/packages/extra/any/adw-gtk-theme/

I lazily commented the paru command out because there may be a time when we need to install something from the AUR in the future.

