### PR TITLE
chore: avoid reinstalling packages already present in base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,11 +7,6 @@ RUN sed -i 's/#Color/Color/g' /etc/pacman.conf && \
     sed -i 's/#MAKEFLAGS="-j2"/MAKEFLAGS="-j$(nproc)"/g' /etc/makepkg.conf && \
     pacman-key --init && pacman-key --populate && \
     pacman -Syu --noconfirm && \
-    pacman -S \
-        wget \
-        base-devel \
-        git \
-        --noconfirm && \
     useradd -m --shell=/bin/bash build && usermod -L build && \
     echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Git base-devel and wget are already in the base image we don't need to install them again.

```
podman run -it quay.io/toolbx/arch-toolbox:latest
pacman -Qq | grep -E "git|wget|base-devel"
base-devel
git
wget
```